### PR TITLE
[YUNIKORN-598] Remove applicationID and partition from allocations list

### DIFF
--- a/src/app/components/apps-view/apps-view.component.ts
+++ b/src/app/components/apps-view/apps-view.component.ts
@@ -76,10 +76,9 @@ export class AppsViewComponent implements OnInit {
 
     this.allocColumnDef = [
       { colId: 'allocationKey', colName: 'Allocation Key' },
-      { colId: 'resource', colName: 'Resource', colFormatter: CommonUtil.resourceColumnFormatter },
-      { colId: 'queueName', colName: 'Queue Name' },
-      { colId: 'priority', colName: 'Priority' },
       { colId: 'nodeId', colName: 'Node ID' },
+      { colId: 'resource', colName: 'Resource', colFormatter: CommonUtil.resourceColumnFormatter },
+      { colId: 'priority', colName: 'Priority' },
     ];
 
     this.allocColumnIds = this.allocColumnDef.map(col => col.colId);

--- a/src/app/components/apps-view/apps-view.component.ts
+++ b/src/app/components/apps-view/apps-view.component.ts
@@ -79,9 +79,7 @@ export class AppsViewComponent implements OnInit {
       { colId: 'resource', colName: 'Resource', colFormatter: CommonUtil.resourceColumnFormatter },
       { colId: 'queueName', colName: 'Queue Name' },
       { colId: 'priority', colName: 'Priority' },
-      { colId: 'partition', colName: 'Partition' },
       { colId: 'nodeId', colName: 'Node ID' },
-      { colId: 'applicationId', colName: 'Application ID' }
     ];
 
     this.allocColumnIds = this.allocColumnDef.map(col => col.colId);


### PR DESCRIPTION
### What is this PR for?
The allocation list is expanded when we click an application. It is unnecessary to display the applicationID and partition again for each of the allocations in the table. This PR removing the applicationID column and the partition column.

### What type of PR is it?
[Improvement]

### Todos

### How should this be tested?
https://travis-ci.com/github/apache/incubator-yunikorn-web/builds/221152738

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-598

### Screenshots (if appropriate)
![yunikorn-598](https://user-images.githubusercontent.com/48027290/112442979-5de01500-8d87-11eb-99a7-f76873a61801.PNG)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No