### PR TITLE
[YUNIKORN-569] Display pod namespace/name for the allocations on the apps/nodes page

### DIFF
--- a/jsdb.json
+++ b/jsdb.json
@@ -88,7 +88,14 @@
       "allocations": [
         {
           "allocationKey": "61b62a65-4eda-11e9-a9ce-025000000001",
-          "allocationTags": null,
+          "allocationTags": {
+            "kubernetes.io/label/dex-job-run-id": "4",
+            "kubernetes.io/label/name": "executor",
+            "kubernetes.io/label/queue": "root.default",
+            "kubernetes.io/label/spark-role": "executor",
+            "kubernetes.io/meta/namespace": "some-namespace",
+            "kubernetes.io/meta/podName": "some-pod-name"
+        },
           "uuid": "71cc082d-486d-4d5f-80e3-e6632a5d9409",
           "resource": "[vcore:1000 memory:1477]",
           "priority": "\u003cnil\u003e",
@@ -99,7 +106,14 @@
         },
         {
           "allocationKey": "66a086ec-4eda-11e9-a9ce-025000000001",
-          "allocationTags": null,
+          "allocationTags": {
+            "kubernetes.io/label/dex-job-run-id": "4",
+            "kubernetes.io/label/name": "executor",
+            "kubernetes.io/label/queue": "root.default",
+            "kubernetes.io/label/spark-role": "executor",
+            "kubernetes.io/meta/namespace": "some-namespace",
+            "kubernetes.io/meta/podName": "some-pod-name"
+        },
           "uuid": "d456a8ba-d9d7-43ff-9e8f-2ee213a14a09",
           "resource": "[vcore:1000 memory:1477]",
           "priority": "\u003cnil\u003e",
@@ -120,7 +134,14 @@
       "allocations": [
         {
           "allocationKey": "61b62a65-4eda-11e9-a9ce-025000000002",
-          "allocationTags": null,
+          "allocationTags": {
+            "kubernetes.io/label/dex-job-run-id": "4",
+            "kubernetes.io/label/name": "executor",
+            "kubernetes.io/label/queue": "root.default",
+            "kubernetes.io/label/spark-role": "executor",
+            "kubernetes.io/meta/namespace": "some-namespace",
+            "kubernetes.io/meta/podName": "some-pod-name"
+        },
           "uuid": "71cc082d-486d-4d5f-80e3-e6632a5d9764",
           "resource": "[vcore:500 memory:1300]",
           "priority": "\u003cnil\u003e",
@@ -131,7 +152,14 @@
         },
         {
           "allocationKey": "66a086ec-4eda-11e9-a9ce-025000000002",
-          "allocationTags": null,
+          "allocationTags": {
+            "kubernetes.io/label/dex-job-run-id": "4",
+            "kubernetes.io/label/name": "executor",
+            "kubernetes.io/label/queue": "root.default",
+            "kubernetes.io/label/spark-role": "executor",
+            "kubernetes.io/meta/namespace": "some-namespace",
+            "kubernetes.io/meta/podName": "some-pod-name"
+        },
           "uuid": "d456a8ba-d9d7-43ff-9e8f-2ee213a157s8",
           "resource": "[vcore:500 memory:1300]",
           "priority": "\u003cnil\u003e",
@@ -152,7 +180,14 @@
       "allocations": [
         {
           "allocationKey": "61b62a65-4eda-11e9-a9ce-025000000002",
-          "allocationTags": null,
+          "allocationTags": {
+            "kubernetes.io/label/dex-job-run-id": "4",
+            "kubernetes.io/label/name": "executor",
+            "kubernetes.io/label/queue": "root.default",
+            "kubernetes.io/label/spark-role": "executor",
+            "kubernetes.io/meta/namespace": "some-namespace",
+            "kubernetes.io/meta/podName": "some-pod-name"
+        },
           "uuid": "71cc082d-486d-4d5f-80e3-e6632a5d9764",
           "resource": "[vcore:500 memory:1300]",
           "priority": "\u003cnil\u003e",
@@ -232,7 +267,14 @@
           "allocations": [
             {
               "allocationKey": "036954e8-78d7-11ea-a9f2-0aafc96ae9e0",
-              "allocationTags": null,
+              "allocationTags": {
+                "kubernetes.io/label/dex-job-run-id": "4",
+                "kubernetes.io/label/name": "executor",
+                "kubernetes.io/label/queue": "root.default",
+                "kubernetes.io/label/spark-role": "executor",
+                "kubernetes.io/meta/namespace": "some-namespace",
+                "kubernetes.io/meta/podName": "some-pod-name"
+            },
               "uuid": "d662b17b-7fdd-44b5-ae37-0f697277dc0f",
               "resource": "[vcore:100]",
               "priority": "<nil>",
@@ -243,7 +285,14 @@
             },
             {
               "allocationKey": "03693499-78d7-11ea-a9f2-0aafc96ae9e0",
-              "allocationTags": null,
+              "allocationTags": {
+                "kubernetes.io/label/dex-job-run-id": "4",
+                "kubernetes.io/label/name": "executor",
+                "kubernetes.io/label/queue": "root.default",
+                "kubernetes.io/label/spark-role": "executor",
+                "kubernetes.io/meta/namespace": "some-namespace",
+                "kubernetes.io/meta/podName": "some-pod-name"
+            },
               "uuid": "4fbe06b7-6e37-4a61-bb33-2c629391cfd0",
               "resource": "[vcore:10]",
               "priority": "<nil>",
@@ -254,7 +303,14 @@
             },
             {
               "allocationKey": "cbae18dd-78d6-11ea-a9f2-0aafc96ae9e0",
-              "allocationTags": null,
+              "allocationTags": {
+                "kubernetes.io/label/dex-job-run-id": "4",
+                "kubernetes.io/label/name": "executor",
+                "kubernetes.io/label/queue": "root.default",
+                "kubernetes.io/label/spark-role": "executor",
+                "kubernetes.io/meta/namespace": "some-namespace",
+                "kubernetes.io/meta/podName": "some-pod-name"
+            },
               "uuid": "b8f28638-17f9-428b-94a1-55b640dda5fa",
               "resource": "[memory:1074 vcore:500]",
               "priority": "<nil>",
@@ -265,7 +321,14 @@
             },
             {
               "allocationKey": "cbaf5077-78d6-11ea-a9f2-0aafc96ae9e0",
-              "allocationTags": null,
+              "allocationTags": {
+                "kubernetes.io/label/dex-job-run-id": "4",
+                "kubernetes.io/label/name": "executor",
+                "kubernetes.io/label/queue": "root.default",
+                "kubernetes.io/label/spark-role": "executor",
+                "kubernetes.io/meta/namespace": "some-namespace",
+                "kubernetes.io/meta/podName": "some-pod-name"
+            },
               "uuid": "efdbbe9a-7929-48c9-afd1-c55f99d2deac",
               "resource": "[memory:1074 vcore:500]",
               "priority": "<nil>",
@@ -276,7 +339,14 @@
             },
             {
               "allocationKey": "cbae6510-78d6-11ea-a9f2-0aafc96ae9e0",
-              "allocationTags": null,
+              "allocationTags": {
+                "kubernetes.io/label/dex-job-run-id": "4",
+                "kubernetes.io/label/name": "executor",
+                "kubernetes.io/label/queue": "root.default",
+                "kubernetes.io/label/spark-role": "executor",
+                "kubernetes.io/meta/namespace": "some-namespace",
+                "kubernetes.io/meta/podName": "some-pod-name"
+            },
               "uuid": "5b911654-0123-480f-86c3-c5ed56871776",
               "resource": "[memory:1074 vcore:500]",
               "priority": "<nil>",
@@ -287,7 +357,14 @@
             },
             {
               "allocationKey": "0f5b3f2d-78d7-11ea-a9f2-0aafc96ae9e0",
-              "allocationTags": null,
+              "allocationTags": {
+                "kubernetes.io/label/dex-job-run-id": "4",
+                "kubernetes.io/label/name": "executor",
+                "kubernetes.io/label/queue": "root.default",
+                "kubernetes.io/label/spark-role": "executor",
+                "kubernetes.io/meta/namespace": "some-namespace",
+                "kubernetes.io/meta/podName": "some-pod-name"
+            },
               "uuid": "fb4f65a8-e434-4ff8-9c7f-e5a1633e0c9e",
               "resource": "[memory:525]",
               "priority": "<nil>",
@@ -298,7 +375,14 @@
             },
             {
               "allocationKey": "0f5b0ae5-78d7-11ea-a9f2-0aafc96ae9e0",
-              "allocationTags": null,
+              "allocationTags": {
+                "kubernetes.io/label/dex-job-run-id": "4",
+                "kubernetes.io/label/name": "executor",
+                "kubernetes.io/label/queue": "root.default",
+                "kubernetes.io/label/spark-role": "executor",
+                "kubernetes.io/meta/namespace": "some-namespace",
+                "kubernetes.io/meta/podName": "some-pod-name"
+            },
               "uuid": "4c33c27e-5b52-41f1-95c1-a81d480f02b9",
               "resource": "[memory:1]",
               "priority": "<nil>",
@@ -309,7 +393,14 @@
             },
             {
               "allocationKey": "0f5f56f1-78d7-11ea-a9f2-0aafc96ae9e0",
-              "allocationTags": null,
+              "allocationTags": {
+                "kubernetes.io/label/dex-job-run-id": "4",
+                "kubernetes.io/label/name": "executor",
+                "kubernetes.io/label/queue": "root.default",
+                "kubernetes.io/label/spark-role": "executor",
+                "kubernetes.io/meta/namespace": "some-namespace",
+                "kubernetes.io/meta/podName": "some-pod-name"
+            },
               "uuid": "65cf4028-5b36-46c2-ac2e-5dbfb00975e9",
               "resource": "[memory:210 vcore:100]",
               "priority": "<nil>",
@@ -354,7 +445,14 @@
           "allocations": [
             {
               "allocationKey": "cbb629c9-78d6-11ea-a9f2-0aafc96ae9e0",
-              "allocationTags": null,
+              "allocationTags": {
+                "kubernetes.io/label/dex-job-run-id": "4",
+                "kubernetes.io/label/name": "executor",
+                "kubernetes.io/label/queue": "root.default",
+                "kubernetes.io/label/spark-role": "executor",
+                "kubernetes.io/meta/namespace": "some-namespace",
+                "kubernetes.io/meta/podName": "some-pod-name"
+            },
               "uuid": "5434e58b-ccb4-4484-9536-312594908b94",
               "resource": "[memory:1074 vcore:500]",
               "priority": "<nil>",
@@ -365,7 +463,14 @@
             },
             {
               "allocationKey": "cbad7dbe-78d6-11ea-a9f2-0aafc96ae9e0",
-              "allocationTags": null,
+              "allocationTags": {
+                "kubernetes.io/label/dex-job-run-id": "4",
+                "kubernetes.io/label/name": "executor",
+                "kubernetes.io/label/queue": "root.default",
+                "kubernetes.io/label/spark-role": "executor",
+                "kubernetes.io/meta/namespace": "some-namespace",
+                "kubernetes.io/meta/podName": "some-pod-name"
+            },
               "uuid": "274c8bba-2144-4d51-bb54-024a29d477f1",
               "resource": "[memory:1074 vcore:500]",
               "priority": "<nil>",
@@ -376,7 +481,14 @@
             },
             {
               "allocationKey": "156690e4-78d7-11ea-a9f2-0aafc96ae9e0",
-              "allocationTags": null,
+              "allocationTags": {
+                "kubernetes.io/label/dex-job-run-id": "4",
+                "kubernetes.io/label/name": "executor",
+                "kubernetes.io/label/queue": "root.default",
+                "kubernetes.io/label/spark-role": "executor",
+                "kubernetes.io/meta/namespace": "some-namespace",
+                "kubernetes.io/meta/podName": "some-pod-name"
+            },
               "uuid": "1b1f8f09-0a32-4eaa-b3e4-8121ffd3fba6",
               "resource": "[memory:525]",
               "priority": "<nil>",
@@ -387,7 +499,14 @@
             },
             {
               "allocationKey": "156689d4-78d7-11ea-a9f2-0aafc96ae9e0",
-              "allocationTags": null,
+              "allocationTags": {
+                "kubernetes.io/label/dex-job-run-id": "4",
+                "kubernetes.io/label/name": "executor",
+                "kubernetes.io/label/queue": "root.default",
+                "kubernetes.io/label/spark-role": "executor",
+                "kubernetes.io/meta/namespace": "some-namespace",
+                "kubernetes.io/meta/podName": "some-pod-name"
+            },
               "uuid": "5804da82-8131-402f-b2e0-8422c445127f",
               "resource": "[memory:1]",
               "priority": "<nil>",
@@ -398,7 +517,14 @@
             },
             {
               "allocationKey": "15694abd-78d7-11ea-a9f2-0aafc96ae9e0",
-              "allocationTags": null,
+              "allocationTags": {
+                "kubernetes.io/label/dex-job-run-id": "4",
+                "kubernetes.io/label/name": "executor",
+                "kubernetes.io/label/queue": "root.default",
+                "kubernetes.io/label/spark-role": "executor",
+                "kubernetes.io/meta/namespace": "some-namespace",
+                "kubernetes.io/meta/podName": "some-pod-name"
+            },
               "uuid": "4c128885-2ed6-4127-89e4-70a490c0265f",
               "resource": "[memory:210 vcore:100]",
               "priority": "<nil>",
@@ -409,7 +535,14 @@
             },
             {
               "allocationKey": "0974c389-78d7-11ea-a9f2-0aafc96ae9e0",
-              "allocationTags": null,
+              "allocationTags": {
+                "kubernetes.io/label/dex-job-run-id": "4",
+                "kubernetes.io/label/name": "executor",
+                "kubernetes.io/label/queue": "root.default",
+                "kubernetes.io/label/spark-role": "executor",
+                "kubernetes.io/meta/namespace": "some-namespace",
+                "kubernetes.io/meta/podName": "some-pod-name"
+            },
               "uuid": "bf9f9c0b-78cf-4e82-976a-3af94f011e23",
               "resource": "[vcore:100]",
               "priority": "<nil>",
@@ -420,7 +553,14 @@
             },
             {
               "allocationKey": "09749d93-78d7-11ea-a9f2-0aafc96ae9e0",
-              "allocationTags": null,
+              "allocationTags": {
+                "kubernetes.io/label/dex-job-run-id": "4",
+                "kubernetes.io/label/name": "executor",
+                "kubernetes.io/label/queue": "root.default",
+                "kubernetes.io/label/spark-role": "executor",
+                "kubernetes.io/meta/namespace": "some-namespace",
+                "kubernetes.io/meta/podName": "some-pod-name"
+            },
               "uuid": "564f2a71-4df8-48ec-9611-300ff260bb9a",
               "resource": "[vcore:10]",
               "priority": "<nil>",
@@ -431,7 +571,14 @@
             },
             {
               "allocationKey": "cbb66256-78d6-11ea-a9f2-0aafc96ae9e0",
-              "allocationTags": null,
+              "allocationTags": {
+                "kubernetes.io/label/dex-job-run-id": "4",
+                "kubernetes.io/label/name": "executor",
+                "kubernetes.io/label/queue": "root.default",
+                "kubernetes.io/label/spark-role": "executor",
+                "kubernetes.io/meta/namespace": "some-namespace",
+                "kubernetes.io/meta/podName": "some-pod-name"
+            },
               "uuid": "a6901552-0762-4b2d-9aca-a88d0168369e",
               "resource": "[memory:1074 vcore:500]",
               "priority": "<nil>",
@@ -465,7 +612,14 @@
           "allocations": [
             {
               "allocationKey": "11946368-78d7-11ea-a9f2-0aafc96ae9e0",
-              "allocationTags": null,
+              "allocationTags": {
+                "kubernetes.io/label/dex-job-run-id": "4",
+                "kubernetes.io/label/name": "executor",
+                "kubernetes.io/label/queue": "root.default",
+                "kubernetes.io/label/spark-role": "executor",
+                "kubernetes.io/meta/namespace": "some-namespace",
+                "kubernetes.io/meta/podName": "some-pod-name"
+            },
               "uuid": "24cab7f8-49ef-499a-be5c-0ab91f0e9af7",
               "resource": "[memory:525]",
               "priority": "<nil>",
@@ -476,7 +630,14 @@
             },
             {
               "allocationKey": "11946e82-78d7-11ea-a9f2-0aafc96ae9e0",
-              "allocationTags": null,
+              "allocationTags": {
+                "kubernetes.io/label/dex-job-run-id": "4",
+                "kubernetes.io/label/name": "executor",
+                "kubernetes.io/label/queue": "root.default",
+                "kubernetes.io/label/spark-role": "executor",
+                "kubernetes.io/meta/namespace": "some-namespace",
+                "kubernetes.io/meta/podName": "some-pod-name"
+            },
               "uuid": "ef9e99de-61b8-4b18-8272-6de7087e8c76",
               "resource": "[memory:1]",
               "priority": "<nil>",
@@ -487,7 +648,14 @@
             },
             {
               "allocationKey": "05ac28a1-78d7-11ea-a9f2-0aafc96ae9e0",
-              "allocationTags": null,
+              "allocationTags": {
+                "kubernetes.io/label/dex-job-run-id": "4",
+                "kubernetes.io/label/name": "executor",
+                "kubernetes.io/label/queue": "root.default",
+                "kubernetes.io/label/spark-role": "executor",
+                "kubernetes.io/meta/namespace": "some-namespace",
+                "kubernetes.io/meta/podName": "some-pod-name"
+            },
               "uuid": "2ac3e691-9a1f-4f5c-a9cc-d6afbc3a10b1",
               "resource": "[vcore:10]",
               "priority": "<nil>",
@@ -498,7 +666,14 @@
             },
             {
               "allocationKey": "05ac2f5a-78d7-11ea-a9f2-0aafc96ae9e0",
-              "allocationTags": null,
+              "allocationTags": {
+                "kubernetes.io/label/dex-job-run-id": "4",
+                "kubernetes.io/label/name": "executor",
+                "kubernetes.io/label/queue": "root.default",
+                "kubernetes.io/label/spark-role": "executor",
+                "kubernetes.io/meta/namespace": "some-namespace",
+                "kubernetes.io/meta/podName": "some-pod-name"
+            },
               "uuid": "23bd81e1-1a8f-4321-b733-d7d47cb614df",
               "resource": "[vcore:100]",
               "priority": "<nil>",
@@ -509,7 +684,14 @@
             },
             {
               "allocationKey": "cbadbb6b-78d6-11ea-a9f2-0aafc96ae9e0",
-              "allocationTags": null,
+              "allocationTags": {
+                "kubernetes.io/label/dex-job-run-id": "4",
+                "kubernetes.io/label/name": "executor",
+                "kubernetes.io/label/queue": "root.default",
+                "kubernetes.io/label/spark-role": "executor",
+                "kubernetes.io/meta/namespace": "some-namespace",
+                "kubernetes.io/meta/podName": "some-pod-name"
+            },
               "uuid": "1899ccb7-c4e2-4564-bb27-5bdbf7289ee9",
               "resource": "[memory:1074 vcore:500]",
               "priority": "<nil>",
@@ -520,7 +702,14 @@
             },
             {
               "allocationKey": "cbbb7fcf-78d6-11ea-a9f2-0aafc96ae9e0",
-              "allocationTags": null,
+              "allocationTags": {
+                "kubernetes.io/label/dex-job-run-id": "4",
+                "kubernetes.io/label/name": "executor",
+                "kubernetes.io/label/queue": "root.default",
+                "kubernetes.io/label/spark-role": "executor",
+                "kubernetes.io/meta/namespace": "some-namespace",
+                "kubernetes.io/meta/podName": "some-pod-name"
+            },
               "uuid": "d9aed216-6732-4502-b04e-60ac489cdb83",
               "resource": "[memory:1074 vcore:500]",
               "priority": "<nil>",
@@ -531,7 +720,14 @@
             },
             {
               "allocationKey": "cbb4cf93-78d6-11ea-a9f2-0aafc96ae9e0",
-              "allocationTags": null,
+              "allocationTags": {
+                "kubernetes.io/label/dex-job-run-id": "4",
+                "kubernetes.io/label/name": "executor",
+                "kubernetes.io/label/queue": "root.default",
+                "kubernetes.io/label/spark-role": "executor",
+                "kubernetes.io/meta/namespace": "some-namespace",
+                "kubernetes.io/meta/podName": "some-pod-name"
+            },
               "uuid": "f0eabf29-96c0-429f-b20e-da5e69252cb1",
               "resource": "[memory:1074 vcore:500]",
               "priority": "<nil>",
@@ -542,7 +738,14 @@
             },
             {
               "allocationKey": "1197b3e0-78d7-11ea-a9f2-0aafc96ae9e0",
-              "allocationTags": null,
+              "allocationTags": {
+                "kubernetes.io/label/dex-job-run-id": "4",
+                "kubernetes.io/label/name": "executor",
+                "kubernetes.io/label/queue": "root.default",
+                "kubernetes.io/label/spark-role": "executor",
+                "kubernetes.io/meta/namespace": "some-namespace",
+                "kubernetes.io/meta/podName": "some-pod-name"
+            },
               "uuid": "8157574d-ed6a-49fe-be92-2b42b11d8679",
               "resource": "[memory:210 vcore:100]",
               "priority": "<nil>",

--- a/src/app/components/apps-view/apps-view.component.ts
+++ b/src/app/components/apps-view/apps-view.component.ts
@@ -75,6 +75,7 @@ export class AppsViewComponent implements OnInit {
     this.appColumnIds = this.appColumnDef.map(col => col.colId).concat('indicatorIcon');
 
     this.allocColumnDef = [
+      { colId: 'displayName', colName: 'Display Name' },
       { colId: 'allocationKey', colName: 'Allocation Key' },
       { colId: 'nodeId', colName: 'Node ID' },
       { colId: 'resource', colName: 'Resource', colFormatter: CommonUtil.resourceColumnFormatter },

--- a/src/app/components/nodes-view/nodes-view.component.ts
+++ b/src/app/components/nodes-view/nodes-view.component.ts
@@ -30,7 +30,7 @@ import { CommonUtil } from '@app/utils/common.util';
 @Component({
   selector: 'app-nodes-view',
   templateUrl: './nodes-view.component.html',
-  styleUrls: ['./nodes-view.component.scss']
+  styleUrls: ['./nodes-view.component.scss'],
 })
 export class NodesViewComponent implements OnInit {
   @ViewChild('nodesViewMatPaginator', { static: true }) nodePaginator: MatPaginator;
@@ -61,23 +61,29 @@ export class NodesViewComponent implements OnInit {
       { colId: 'partitionName', colName: 'Partition Name' },
       { colId: 'capacity', colName: 'Capacity', colFormatter: CommonUtil.resourceColumnFormatter },
       { colId: 'occupied', colName: 'Used', colFormatter: CommonUtil.resourceColumnFormatter },
-      { colId: 'allocated', colName: 'Allocated', colFormatter: CommonUtil.resourceColumnFormatter },
-      { colId: 'available', colName: 'Available', colFormatter: CommonUtil.resourceColumnFormatter }
+      {
+        colId: 'allocated',
+        colName: 'Allocated',
+        colFormatter: CommonUtil.resourceColumnFormatter,
+      },
+      {
+        colId: 'available',
+        colName: 'Available',
+        colFormatter: CommonUtil.resourceColumnFormatter,
+      },
     ];
 
-    this.nodeColumnIds = this.nodeColumnDef.map(col => col.colId).concat('indicatorIcon');
+    this.nodeColumnIds = this.nodeColumnDef.map((col) => col.colId).concat('indicatorIcon');
 
     this.allocColumnDef = [
       { colId: 'allocationKey', colName: 'Allocation Key' },
       { colId: 'resource', colName: 'Resource', colFormatter: CommonUtil.resourceColumnFormatter },
       { colId: 'queueName', colName: 'Queue Name' },
       { colId: 'priority', colName: 'Priority' },
-      { colId: 'partition', colName: 'Partition' },
-      { colId: 'nodeId', colName: 'Node ID' },
-      { colId: 'applicationId', colName: 'Application ID' }
+      { colId: 'applicationId', colName: 'Application ID' },
     ];
 
-    this.allocColumnIds = this.allocColumnDef.map(col => col.colId);
+    this.allocColumnIds = this.allocColumnDef.map((col) => col.colId);
 
     this.spinner.show();
     this.scheduler
@@ -87,13 +93,13 @@ export class NodesViewComponent implements OnInit {
           this.spinner.hide();
         })
       )
-      .subscribe(data => {
+      .subscribe((data) => {
         this.nodeDataSource.data = data;
       });
   }
 
   unselectAllRowsButOne(row: NodeInfo) {
-    this.nodeDataSource.data.map(node => {
+    this.nodeDataSource.data.map((node) => {
       if (node !== row) {
         node.isSelected = false;
       }

--- a/src/app/components/nodes-view/nodes-view.component.ts
+++ b/src/app/components/nodes-view/nodes-view.component.ts
@@ -73,7 +73,7 @@ export class NodesViewComponent implements OnInit {
       },
     ];
 
-    this.nodeColumnIds = this.nodeColumnDef.map((col) => col.colId).concat('indicatorIcon');
+    this.nodeColumnIds = this.nodeColumnDef.map(col => col.colId).concat('indicatorIcon');
 
     this.allocColumnDef = [
       { colId: 'allocationKey', colName: 'Allocation Key' },
@@ -83,7 +83,7 @@ export class NodesViewComponent implements OnInit {
       { colId: 'applicationId', colName: 'Application ID' },
     ];
 
-    this.allocColumnIds = this.allocColumnDef.map((col) => col.colId);
+    this.allocColumnIds = this.allocColumnDef.map(col => col.colId);
 
     this.spinner.show();
     this.scheduler
@@ -93,13 +93,13 @@ export class NodesViewComponent implements OnInit {
           this.spinner.hide();
         })
       )
-      .subscribe((data) => {
+      .subscribe(data => {
         this.nodeDataSource.data = data;
       });
   }
 
   unselectAllRowsButOne(row: NodeInfo) {
-    this.nodeDataSource.data.map((node) => {
+    this.nodeDataSource.data.map(node => {
       if (node !== row) {
         node.isSelected = false;
       }

--- a/src/app/models/alloc-info.model.ts
+++ b/src/app/models/alloc-info.model.ts
@@ -18,6 +18,7 @@
 
 export class AllocationInfo {
   constructor(
+    public displayName: string,
     public allocationKey: string,
     public allocationTags: string,
     public uuid: string,

--- a/src/app/services/scheduler/scheduler.service.ts
+++ b/src/app/services/scheduler/scheduler.service.ts
@@ -33,14 +33,14 @@ import { NodeInfo } from '@app/models/node-info.model';
 import { NOT_AVAILABLE } from '@app/utils/constants';
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class SchedulerService {
   constructor(private httpClient: HttpClient, private envConfig: EnvconfigService) {}
 
   public fetchClusterList(): Observable<ClusterInfo[]> {
     const clusterUrl = `${this.envConfig.getSchedulerWebAddress()}/ws/v1/clusters`;
-    return this.httpClient.get(clusterUrl).pipe(map(data => data as ClusterInfo[]));
+    return this.httpClient.get(clusterUrl).pipe(map((data) => data as ClusterInfo[]));
   }
 
   public fetchSchedulerQueues(): Observable<any> {
@@ -61,7 +61,7 @@ export class SchedulerService {
         const partitionName = data['partitionname'] || '';
         return {
           rootQueue,
-          partitionName
+          partitionName,
         };
       })
     );
@@ -73,7 +73,7 @@ export class SchedulerService {
       map((data: any) => {
         const result = [];
         if (data && data.length > 0) {
-          data.forEach(app => {
+          data.forEach((app) => {
             const appInfo = new AppInfo(
               app['applicationID'],
               this.formatCapacity(this.splitCapacity(app['usedResource'], NOT_AVAILABLE)),
@@ -86,8 +86,11 @@ export class SchedulerService {
             const allocations = app['allocations'];
             if (allocations && allocations.length > 0) {
               const appAllocations = [];
-              allocations.forEach(alloc => {
-                alloc.allocationKey = alloc.allocationTags['kubernetes.io/meta/namespace'] + '/\r' + alloc.allocationTags['kubernetes.io/meta/podName'];
+              allocations.forEach((alloc) => {
+                alloc.allocationKey =
+                  alloc.allocationTags['kubernetes.io/meta/namespace'] +
+                  '/\r' +
+                  alloc.allocationTags['kubernetes.io/meta/podName'];
                 appAllocations.push(
                   new AllocationInfo(
                     alloc['allocationKey'],
@@ -119,7 +122,7 @@ export class SchedulerService {
         const result = [];
 
         if (data && data.length) {
-          data.forEach(history => {
+          data.forEach((history) => {
             result.push(
               new HistoryInfo(Math.floor(history.timestamp / 1e6), +history.totalApplications)
             );
@@ -138,7 +141,7 @@ export class SchedulerService {
         const result = [];
 
         if (data && data.length) {
-          data.forEach(history => {
+          data.forEach((history) => {
             result.push(
               new HistoryInfo(Math.floor(history.timestamp / 1e6), +history.totalContainers)
             );
@@ -161,7 +164,7 @@ export class SchedulerService {
           for (const info of data) {
             const nodesInfoData = info.nodesInfo || [];
 
-            nodesInfoData.forEach(node => {
+            nodesInfoData.forEach((node) => {
               const nodeInfo = new NodeInfo(
                 node['nodeID'],
                 node['hostName'],
@@ -178,8 +181,11 @@ export class SchedulerService {
               if (allocations && allocations.length > 0) {
                 const appAllocations = [];
 
-                allocations.forEach(alloc => {
-                  alloc.allocationKey = alloc.allocationTags['kubernetes.io/meta/namespace'] + '/\r' + alloc.allocationKey['kubernetes.io/meta/podName'];
+                allocations.forEach((alloc) => {
+                  alloc.allocationKey =
+                    alloc.allocationTags['kubernetes.io/meta/namespace'] +
+                    '/\r' +
+                    alloc.allocationKey['kubernetes.io/meta/podName'];
                   appAllocations.push(
                     new AllocationInfo(
                       alloc['allocationKey'],
@@ -211,7 +217,7 @@ export class SchedulerService {
   private generateQueuesTree(data: any, currentQueue: QueueInfo) {
     if (data && data.queues && data.queues.length > 0) {
       const chilrenQs = [];
-      data.queues.forEach(queueData => {
+      data.queues.forEach((queueData) => {
         const childQueue = new QueueInfo();
         childQueue.queueName = '' + queueData.queuename;
         childQueue.state = queueData.status || 'RUNNING';
@@ -247,10 +253,10 @@ export class SchedulerService {
     if (data.properties && !CommonUtil.isEmpty(data.properties)) {
       const dataProps = Object.entries<string>(data.properties);
 
-      queue.queueProperties = dataProps.map(prop => {
+      queue.queueProperties = dataProps.map((prop) => {
         return {
           name: prop[0],
-          value: prop[1]
+          value: prop[1],
         } as QueuePropertyItem;
       });
     } else {
@@ -266,7 +272,7 @@ export class SchedulerService {
 
     const resources: ResourceInfo = {
       memory: defaultValue,
-      vcore: defaultValue
+      vcore: defaultValue,
     };
 
     for (const resource of splitted) {

--- a/src/app/services/scheduler/scheduler.service.ts
+++ b/src/app/services/scheduler/scheduler.service.ts
@@ -40,7 +40,7 @@ export class SchedulerService {
 
   public fetchClusterList(): Observable<ClusterInfo[]> {
     const clusterUrl = `${this.envConfig.getSchedulerWebAddress()}/ws/v1/clusters`;
-    return this.httpClient.get(clusterUrl).pipe(map((data) => data as ClusterInfo[]));
+    return this.httpClient.get(clusterUrl).pipe(map(data => data as ClusterInfo[]));
   }
 
   public fetchSchedulerQueues(): Observable<any> {
@@ -129,7 +129,7 @@ export class SchedulerService {
         const result = [];
 
         if (data && data.length) {
-          data.forEach((history) => {
+          data.forEach(history => {
             result.push(
               new HistoryInfo(Math.floor(history.timestamp / 1e6), +history.totalApplications)
             );
@@ -148,7 +148,7 @@ export class SchedulerService {
         const result = [];
 
         if (data && data.length) {
-          data.forEach((history) => {
+          data.forEach(history => {
             result.push(
               new HistoryInfo(Math.floor(history.timestamp / 1e6), +history.totalContainers)
             );
@@ -171,7 +171,7 @@ export class SchedulerService {
           for (const info of data) {
             const nodesInfoData = info.nodesInfo || [];
 
-            nodesInfoData.forEach((node) => {
+            nodesInfoData.forEach(node => {
               const nodeInfo = new NodeInfo(
                 node['nodeID'],
                 node['hostName'],
@@ -188,7 +188,7 @@ export class SchedulerService {
               if (allocations && allocations.length > 0) {
                 const appAllocations = [];
 
-                allocations.forEach((alloc) => {
+                allocations.forEach(alloc => {
                   if (
                     alloc.allocationTags['kubernetes.io/meta/namespace'] &&
                     alloc.allocationTags['kubernetes.io/meta/podName']
@@ -231,7 +231,7 @@ export class SchedulerService {
   private generateQueuesTree(data: any, currentQueue: QueueInfo) {
     if (data && data.queues && data.queues.length > 0) {
       const chilrenQs = [];
-      data.queues.forEach((queueData) => {
+      data.queues.forEach(queueData => {
         const childQueue = new QueueInfo();
         childQueue.queueName = '' + queueData.queuename;
         childQueue.state = queueData.status || 'RUNNING';
@@ -267,7 +267,7 @@ export class SchedulerService {
     if (data.properties && !CommonUtil.isEmpty(data.properties)) {
       const dataProps = Object.entries<string>(data.properties);
 
-      queue.queueProperties = dataProps.map((prop) => {
+      queue.queueProperties = dataProps.map(prop => {
         return {
           name: prop[0],
           value: prop[1],

--- a/src/app/services/scheduler/scheduler.service.ts
+++ b/src/app/services/scheduler/scheduler.service.ts
@@ -87,6 +87,7 @@ export class SchedulerService {
             if (allocations && allocations.length > 0) {
               const appAllocations = [];
               allocations.forEach(alloc => {
+                alloc.allocationKey = alloc.allocationTags['kubernetes.io/meta/namespace'] + '/\r' + alloc.allocationTags['kubernetes.io/meta/podName'];
                 appAllocations.push(
                   new AllocationInfo(
                     alloc['allocationKey'],
@@ -178,6 +179,7 @@ export class SchedulerService {
                 const appAllocations = [];
 
                 allocations.forEach(alloc => {
+                  alloc.allocationKey = alloc.allocationTags['kubernetes.io/meta/namespace'] + '/\r' + alloc.allocationKey['kubernetes.io/meta/podName'];
                   appAllocations.push(
                     new AllocationInfo(
                       alloc['allocationKey'],

--- a/src/app/services/scheduler/scheduler.service.ts
+++ b/src/app/services/scheduler/scheduler.service.ts
@@ -73,7 +73,7 @@ export class SchedulerService {
       map((data: any) => {
         const result = [];
         if (data && data.length > 0) {
-          data.forEach((app) => {
+          data.forEach(app => {
             const appInfo = new AppInfo(
               app['applicationID'],
               this.formatCapacity(this.splitCapacity(app['usedResource'], NOT_AVAILABLE)),
@@ -86,7 +86,7 @@ export class SchedulerService {
             const allocations = app['allocations'];
             if (allocations && allocations.length > 0) {
               const appAllocations = [];
-              allocations.forEach((alloc) => {
+              allocations.forEach(alloc => {
                 if (
                   alloc.allocationTags['kubernetes.io/meta/namespace'] &&
                   alloc.allocationTags['kubernetes.io/meta/podName']

--- a/src/app/services/scheduler/scheduler.service.ts
+++ b/src/app/services/scheduler/scheduler.service.ts
@@ -40,7 +40,7 @@ export class SchedulerService {
 
   public fetchClusterList(): Observable<ClusterInfo[]> {
     const clusterUrl = `${this.envConfig.getSchedulerWebAddress()}/ws/v1/clusters`;
-    return this.httpClient.get(clusterUrl).pipe(map(data => data as ClusterInfo[]));
+    return this.httpClient.get(clusterUrl).pipe(map((data) => data as ClusterInfo[]));
   }
 
   public fetchSchedulerQueues(): Observable<any> {
@@ -73,7 +73,7 @@ export class SchedulerService {
       map((data: any) => {
         const result = [];
         if (data && data.length > 0) {
-          data.forEach(app => {
+          data.forEach((app) => {
             const appInfo = new AppInfo(
               app['applicationID'],
               this.formatCapacity(this.splitCapacity(app['usedResource'], NOT_AVAILABLE)),
@@ -86,8 +86,9 @@ export class SchedulerService {
             const allocations = app['allocations'];
             if (allocations && allocations.length > 0) {
               const appAllocations = [];
-              allocations.forEach(alloc => {
+              allocations.forEach((alloc) => {
                 if (
+                  alloc.allocationTags &&
                   alloc.allocationTags['kubernetes.io/meta/namespace'] &&
                   alloc.allocationTags['kubernetes.io/meta/podName']
                 ) {
@@ -95,7 +96,7 @@ export class SchedulerService {
                     'displayName'
                   ] = `${alloc.allocationTags['kubernetes.io/meta/namespace']}/\r${alloc.allocationTags['kubernetes.io/meta/podName']}`;
                 } else {
-                  alloc['displayName'] = `some-namespace/undefined`;
+                  alloc['displayName'] = `<nil>`;
                 }
                 appAllocations.push(
                   new AllocationInfo(
@@ -129,7 +130,7 @@ export class SchedulerService {
         const result = [];
 
         if (data && data.length) {
-          data.forEach(history => {
+          data.forEach((history) => {
             result.push(
               new HistoryInfo(Math.floor(history.timestamp / 1e6), +history.totalApplications)
             );
@@ -148,7 +149,7 @@ export class SchedulerService {
         const result = [];
 
         if (data && data.length) {
-          data.forEach(history => {
+          data.forEach((history) => {
             result.push(
               new HistoryInfo(Math.floor(history.timestamp / 1e6), +history.totalContainers)
             );
@@ -171,7 +172,7 @@ export class SchedulerService {
           for (const info of data) {
             const nodesInfoData = info.nodesInfo || [];
 
-            nodesInfoData.forEach(node => {
+            nodesInfoData.forEach((node) => {
               const nodeInfo = new NodeInfo(
                 node['nodeID'],
                 node['hostName'],
@@ -188,7 +189,7 @@ export class SchedulerService {
               if (allocations && allocations.length > 0) {
                 const appAllocations = [];
 
-                allocations.forEach(alloc => {
+                allocations.forEach((alloc) => {
                   if (
                     alloc.allocationTags['kubernetes.io/meta/namespace'] &&
                     alloc.allocationTags['kubernetes.io/meta/podName']
@@ -231,7 +232,7 @@ export class SchedulerService {
   private generateQueuesTree(data: any, currentQueue: QueueInfo) {
     if (data && data.queues && data.queues.length > 0) {
       const chilrenQs = [];
-      data.queues.forEach(queueData => {
+      data.queues.forEach((queueData) => {
         const childQueue = new QueueInfo();
         childQueue.queueName = '' + queueData.queuename;
         childQueue.state = queueData.status || 'RUNNING';
@@ -267,7 +268,7 @@ export class SchedulerService {
     if (data.properties && !CommonUtil.isEmpty(data.properties)) {
       const dataProps = Object.entries<string>(data.properties);
 
-      queue.queueProperties = dataProps.map(prop => {
+      queue.queueProperties = dataProps.map((prop) => {
         return {
           name: prop[0],
           value: prop[1],

--- a/src/app/services/scheduler/scheduler.service.ts
+++ b/src/app/services/scheduler/scheduler.service.ts
@@ -198,7 +198,7 @@ export class SchedulerService {
                       'displayName'
                     ] = `${alloc.allocationTags['kubernetes.io/meta/namespace']}/\r${alloc.allocationTags['kubernetes.io/meta/podName']}`;
                   } else {
-                    alloc['displayName'] = `some-namespace/undefined`;
+                    alloc['displayName'] = '<nil>';
                   }
                   appAllocations.push(
                     new AllocationInfo(

--- a/src/app/services/scheduler/scheduler.service.ts
+++ b/src/app/services/scheduler/scheduler.service.ts
@@ -31,7 +31,6 @@ import { AllocationInfo } from '@app/models/alloc-info.model';
 import { HistoryInfo } from '@app/models/history-info.model';
 import { NodeInfo } from '@app/models/node-info.model';
 import { NOT_AVAILABLE } from '@app/utils/constants';
-import { connectableObservableDescriptor } from 'rxjs/internal/observable/ConnectableObservable';
 
 @Injectable({
   providedIn: 'root',
@@ -88,12 +87,16 @@ export class SchedulerService {
             if (allocations && allocations.length > 0) {
               const appAllocations = [];
               allocations.forEach((alloc) => {
-                let displayName =
-                  alloc.allocationTags['kubernetes.io/meta/namespace'] +
-                  '/\r' +
-                  alloc.allocationTags['kubernetes.io/meta/podName'];
-                alloc['displayName'] = displayName;
-                console.log(alloc['displayName']);
+                if (
+                  alloc.allocationTags['kubernetes.io/meta/namespace'] &&
+                  alloc.allocationTags['kubernetes.io/meta/podName']
+                ) {
+                  alloc[
+                    'displayName'
+                  ] = `${alloc.allocationTags['kubernetes.io/meta/namespace']}/\r${alloc.allocationTags['kubernetes.io/meta/podName']}`;
+                } else {
+                  alloc['displayName'] = `some-namespace/undefined`;
+                }
                 appAllocations.push(
                   new AllocationInfo(
                     alloc['displayName'],
@@ -186,10 +189,16 @@ export class SchedulerService {
                 const appAllocations = [];
 
                 allocations.forEach((alloc) => {
-                  alloc.allocationKey =
-                    alloc.allocationTags['kubernetes.io/meta/namespace'] +
-                    '/\r' +
-                    alloc.allocationKey['kubernetes.io/meta/podName'];
+                  if (
+                    alloc.allocationTags['kubernetes.io/meta/namespace'] &&
+                    alloc.allocationTags['kubernetes.io/meta/podName']
+                  ) {
+                    alloc[
+                      'displayName'
+                    ] = `${alloc.allocationTags['kubernetes.io/meta/namespace']}/\r${alloc.allocationTags['kubernetes.io/meta/podName']}`;
+                  } else {
+                    alloc['displayName'] = `some-namespace/undefined`;
+                  }
                   appAllocations.push(
                     new AllocationInfo(
                       alloc['displayName'],

--- a/src/app/services/scheduler/scheduler.service.ts
+++ b/src/app/services/scheduler/scheduler.service.ts
@@ -31,6 +31,7 @@ import { AllocationInfo } from '@app/models/alloc-info.model';
 import { HistoryInfo } from '@app/models/history-info.model';
 import { NodeInfo } from '@app/models/node-info.model';
 import { NOT_AVAILABLE } from '@app/utils/constants';
+import { connectableObservableDescriptor } from 'rxjs/internal/observable/ConnectableObservable';
 
 @Injectable({
   providedIn: 'root',
@@ -87,12 +88,15 @@ export class SchedulerService {
             if (allocations && allocations.length > 0) {
               const appAllocations = [];
               allocations.forEach((alloc) => {
-                alloc.allocationKey =
+                let displayName =
                   alloc.allocationTags['kubernetes.io/meta/namespace'] +
                   '/\r' +
                   alloc.allocationTags['kubernetes.io/meta/podName'];
+                alloc['displayName'] = displayName;
+                console.log(alloc['displayName']);
                 appAllocations.push(
                   new AllocationInfo(
+                    alloc['displayName'],
                     alloc['allocationKey'],
                     alloc['allocationTags'],
                     alloc['uuid'],
@@ -188,6 +192,7 @@ export class SchedulerService {
                     alloc.allocationKey['kubernetes.io/meta/podName'];
                   appAllocations.push(
                     new AllocationInfo(
+                      alloc['displayName'],
                       alloc['allocationKey'],
                       alloc['allocationTags'],
                       alloc['uuid'],


### PR DESCRIPTION
### What is this PR for?
Display pod namespace/name for the allocations on the apps/nodes page. Make application-key human readable.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-569

### How should this be tested?
https://github.com/apache/incubator-yunikorn-web/pull/54/checks?check_run_id=2212230697

### Screenshots (if appropriate)
<img width="1430" alt="截圖 2021-03-28 下午7 24 42" src="https://user-images.githubusercontent.com/48027290/112750454-46a95d80-8ffb-11eb-8704-a31a196c170c.png">
<img width="1434" alt="截圖 2021-03-28 下午7 24 30" src="https://user-images.githubusercontent.com/48027290/112750459-4c06a800-8ffb-11eb-88cc-eedb879e85ec.png">


### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.