### PR TITLE
[YUNIKORN-771] make license-check fix for linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ jobs:
         - npm install -g protractor
         - npm install yarn
       script:
-        - make check-license
+        - make license-check
         - make build-prod
         - yarn test:coverage
         - yarn lint


### PR DESCRIPTION
### What is this PR for?
The license check run as part of the PR workflow always passes when run on linux.
The recursive grep redirect to a variable does not work.

### What type of PR is it?
* [X] - Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-771

### How should this be tested?
NA