### PR TITLE
[YUNIKORN-849] The web can't get correct partition name from "/ws/v1/…

### DIFF
--- a/src/app/services/scheduler/scheduler.service.ts
+++ b/src/app/services/scheduler/scheduler.service.ts
@@ -64,7 +64,7 @@ export class SchedulerService {
           this.fillQueueProperties(rootQueueData, rootQueue);
           rootQueue = this.generateQueuesTree(rootQueueData, rootQueue);
         }
-        const partitionName = data['partitionname'] || '';
+        const partitionName = data['partitionName'] || '';
         return {
           rootQueue,
           partitionName,


### PR DESCRIPTION
…queues" since the key was changed from "partitionname" to "partitionName"

### What is this PR for?
the key was changed by https://github.com/apache/incubator-yunikorn-core/commit/160343fa2caacc9c825a3a92e717376a3f1c1f22.

Noted that this issue does not make web repo use new API. It just fix web to show the correct partition name.


### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-849

### How should this be tested?

### Screenshots (if appropriate)

**config**
```yaml
 partitions:
  - name: notdefault
    nodesortpolicy:
        type: binpacking
    placementrules:
      - name: provided
        create: true
    queues:
      - name: root
        properties:
          application.sort.policy: stateaware
```

**Before**

<img width="487" alt="截圖 2021-09-16 下午2 04 18" src="https://user-images.githubusercontent.com/6234750/133558357-2a07dd78-4f3b-45bb-9150-5522c90b71cf.png">


**After**
<img width="490" alt="截圖 2021-09-16 下午2 01 32" src="https://user-images.githubusercontent.com/6234750/133558143-0704dd65-a10c-4494-b1d3-eb3fa28f3aa0.png">



### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
