### PR TITLE
[YUNIKORN-1105] Use bytes as base unit for memory

### DIFF
--- a/src/app/utils/common.util.ts
+++ b/src/app/utils/common.util.ts
@@ -30,8 +30,18 @@ export class CommonUtil {
   }
 
   static formatMemory(value: number | string): string {
-    let unit = 'MB';
+    let unit = 'bytes';
     let toValue = +value;
+
+    if (toValue / 1000 >= 1) {
+      toValue = toValue / 1000;
+      unit = 'KB';
+    }
+
+    if (toValue / 1000 >= 1) {
+      toValue = toValue / 1000;
+      unit = 'MB';
+    }
 
     if (toValue / 1000 >= 1) {
       toValue = toValue / 1000;


### PR DESCRIPTION
### What is this PR for?
Use bytes as the base unit of memory, as the scheduler will now use absolute values.

This should be committed at the same time as the shim PR.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1105

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
